### PR TITLE
Merge fixes

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -247,9 +247,6 @@ cycle_time: 0.010
 #   LED Control
 #####################################################################
 
-[output_pin pcb_led]
-pin: !pth:gpio8
-
 [neopixel indicator]
 pin: gpio24
 chain_count: 5

--- a/printer.cfg
+++ b/printer.cfg
@@ -20,9 +20,6 @@
 
 
 [include fluidd.cfg]
-[virtual_sdcard]
-path: /home/pi/printer_data/gcodes
-on_error_gcode: CANCEL_PRINT
 
 [mcu]
 #####################################################################


### PR DESCRIPTION
- **Remove debug LED override**
  Remove `pcb_LED` override of bootloader's debug LED
  

- **Remove duplicate virtual_sd definition**
  Virtual SD is already declared in fluid.cfg and explicit path declaration here produces difficult to diagnose errors if installed under other users
  