### PR TITLE
Update printer.cfg

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -286,11 +286,11 @@ timeout: 1800
 
 ## To be used with BED_SCREWS_ADJUST
 [bed_screws]
-screw1: 5,170
+screw1: 5,45
 screw1_name: fl
-screw2: 180,170
+screw2: 180,45
 screw2_name: fr
-screw3: 90,20
+screw3: 90,160
 screw3_name: bm
 
 #####################################################################


### PR DESCRIPTION
Updated [bed_screws] with the correct screw locations. Locations were inverted! Makes bed leveling much easier