### PR TITLE
The New Start Update

### DIFF
--- a/positron_macros.cfg
+++ b/positron_macros.cfg
@@ -181,7 +181,7 @@ gcode:
     {% set x_center = (printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float) / 2.0 %}
     {% set y_center = (printer.toolhead.axis_maximum.y|float + printer.toolhead.axis_minimum.y|float) / 2.0 %}
     G90
-    G1 X{x_center} Y{y_center} F7800
+    G0 X{x_center} Y{x_center} F7800
 
 
 [gcode_macro FRONT]
@@ -191,19 +191,31 @@ gcode:
     {% set x_center = (printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float) / 2.0 %}
     {% set y_front = printer.toolhead.axis_maximum.y|float - 10 %}
     G90
-    G1 X{x_center} Y{y_front} F7800
+    G0 X{x_center} Y{y_front} F7800
+
+
+[gcode_macro LOAD_POSITION]
+description: Move the toolhead to the front left corner
+gcode:
+    G28 X Y O
+    {% set x_left  = printer.toolhead.axis_minimum.x|float + 10 %}
+    {% set y_front = printer.toolhead.axis_maximum.y|float - 10 %}
+    G90
+    G0 X{x_left} Y{y_front} F7800
 
 
 #####################################################################
 #   Filament Macros
 #####################################################################
 
-[gcode_macro M600]
-description: Temporary self-service M600: PAUSE and UNLOAD_FILAMENT
-gcode: 
-    PAUSE
-    RESPOND MSG="Unloading filament, reload before resuming"
-    UNLOAD_FILAMENT
+[gcode_macro _FILAMENT_CHANGE_VARIABLES]
+variable_preload_speed: 400
+variable_preload_distance: 30
+variable_load_speed: 2000
+variable_load_distance: 300
+variable_prime_speed: 200
+variable_prime_distamce: 30
+gcode:
 
 
 [gcode_macro UNLOAD_FILAMENT]
@@ -213,10 +225,13 @@ gcode:
     {% set MIN_TEMP = params.TEMP|default(210)|float * 0.98 %}
     {% set CURRENT_TARGET = printer.extruder.target|float %}
     SAVE_GCODE_STATE NAME=UNLOAD_FILAMENT
-    G28 O
-    G91                         ; relative positioning
-    G1 Z20                      ; move nozzle upwards
-    FRONT                       ; move the toolhead to the front
+
+    ;Set EXTRUDER_TEMP
+    M104 S{EXTRUDER_TEMP}
+    
+    ;Home if needed (per axis) and move to load position
+    G28 X Y Z O
+    LOAD_POSITION
 
     {% if EXTRUDER_TEMP != 0 %}
         LED_PENDING
@@ -227,13 +242,13 @@ gcode:
     {% endif %}
     LED_WORKING
     M83                         ; set extruder to relative mode
-    G1 E10 F300                 ; extrude a little to soften tip
-    G1 E-30 F3600               ; quickly retract a small amount to elimate stringing
+    G0 E10 F300                 ; extrude a little to soften tip
+    G0 E-30 F3600               ; quickly retract a small amount to elimate stringing
     G4 P200                     ; pause for a short amount of time
     G1 E-400 F1200              ; retract slowly the rest of the way
     M400                        ; wait for moves to finish
     RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT
-    M300 P400                   ; long beep to indicate unload complete
+    M300 P400                   ; beep to indicate unload complete
     M117 Unload Complete!
     LED_READY
 
@@ -272,6 +287,17 @@ gcode:
     RESTORE_GCODE_STATE NAME=LOAD_FILAMENT
     M117 Load Complete!
     LED_READY
+
+
+[gcode_macro M600]
+description: Implements M600 gcode (pause & filament change)
+gcode: 
+    SAVE_GCODE_STATE NAME=M600
+    PAUSE
+    UNLOAD_FILAMENT
+    LOAD_FILAMENT
+    RESUME
+    RESTORE_GCODE_STATE NAME=M600
 
 
 #####################################################################
@@ -405,6 +431,13 @@ description: sets the _indicators to teal
 gcode:
     SET_LED LED=_indicator RED=0 GREEN=0.4 BLUE=0.2 INDEX=1 TRANSMIT=0
     SET_LED LED=_indicator RED=0 GREEN=0.4 BLUE=0.2 INDEX=3 
+
+
+[gcode_macro LED_ALERT]
+description: sets the _indicators to yellow
+gcode:
+    SET_LED LED=_indicator RED=0.6 GREEN=0.6 BLUE=0 INDEX=1 TRANSMIT=0
+    SET_LED LED=_indicator RED=0.6 GREEN=0.6 BLUE=0 INDEX=3 
 
 
 [gcode_macro LED_WORKING]

--- a/positron_macros.cfg
+++ b/positron_macros.cfg
@@ -209,48 +209,72 @@ gcode:
 #####################################################################
 
 [gcode_macro _FILAMENT_CHANGE_VARIABLES]
+description: Variables for filament changing macros
 variable_preload_speed: 400
 variable_preload_distance: 30
 variable_load_speed: 2000
 variable_load_distance: 300
 variable_prime_speed: 200
-variable_prime_distamce: 30
+variable_prime_distance: 30
+variable_default_temperature: 210
 gcode:
 
 
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads filament from toolhead. EXTRUDER_TEMP defaults to 210 if hotend is cold
 gcode:
-    {% set EXTRUDER_TEMP = params.TEMP|default(210)|int %}
-    {% set MIN_TEMP = params.TEMP|default(210)|float * 0.98 %}
+    ;define temperature local names
     {% set CURRENT_TARGET = printer.extruder.target|float %}
+    {% set MIN_TARGET = printer.extruder.min_extrude_temp|float %}
+    {% set EXPLICIT_TARGET = params.TEMP|default(0)|int %}
+    {% set DEFAULT_TARGET = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].default_temperature|float %}
+
+    ;define distance local names
+    {% set PRELOAD_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].preload_distance|float %}
+    {% set LOAD_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].load_distance|float %}
+    {% set PRIME_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_distance|float %}
+
+    ;define speed local names
+    {% set PRELOAD_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].preload_speed|float %}
+    {% set LOAD_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].load_speed|float %}
+    {% set PRIME_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_speed|float %}
+
+    ;save state
     SAVE_GCODE_STATE NAME=UNLOAD_FILAMENT
 
-    ;Set EXTRUDER_TEMP
-    M104 S{EXTRUDER_TEMP}
-    
-    ;Home if needed (per axis) and move to load position
+    ;home if needed (per axis) and move to load position
+    LED_WORKING
     G28 X Y Z O
     LOAD_POSITION
 
-    {% if EXTRUDER_TEMP != 0 %}
-        LED_PENDING
-        {% if CURRENT_TARGET < EXTRUDER_TEMP %}
-            M104 S{EXTRUDER_TEMP} ; only heat up if the current extruder is not already hot
-        {% endif %}
-        TEMPERATURE_WAIT SENSOR="extruder" MINIMUM={MIN_TEMP} ; wait for min extrude temp to reach
+    ;set/wait for extruder temperature
+    LED_PENDING
+    ; heat to parameter if valid
+    {% if EXPLICIT_TARGET >= MIN_TARGET %}
+        M109 S{EXPLICIT_TARGET}
+    ; else heat to standing target if valid
+    {% elif CURRENT_TARGET > MIN_TARGET %}
+        M109 S{CURRENT_TARGET}
+    ; else heat to default target
+    {% else %}
+        M109 S{DEFAULT_TARGET}
     {% endif %}
+
+    ;deprime and unload
     LED_WORKING
-    M83                         ; set extruder to relative mode
-    G0 E10 F300                 ; extrude a little to soften tip
-    G0 E-30 F3600               ; quickly retract a small amount to elimate stringing
-    G4 P200                     ; pause for a short amount of time
-    G1 E-400 F1200              ; retract slowly the rest of the way
-    M400                        ; wait for moves to finish
-    RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT
-    M300 P400                   ; beep to indicate unload complete
-    M117 Unload Complete!
+    M83
+    G0 E-{PRIME_DISTANCE} F{PRIME_SPEED}
+    G4 P200
+    G1 E-{LOAD_DISTANCE} F{LOAD_SPEED}
+    G4 P200
+    G1 E-{PRELOAD_DISTANCE * 3} F{PRELOAD_SPEED}
+    M400
+
+    ;signal end of unload
+    M300 P400
     LED_READY
+    M117 Unload complete
+    RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT
 
 
 [gcode_macro LOAD_FILAMENT]

--- a/positron_macros.cfg
+++ b/positron_macros.cfg
@@ -264,11 +264,12 @@ gcode:
     ;deprime and unload
     LED_WORKING
     M83
-    G0 E-{PRIME_DISTANCE} F{PRIME_SPEED}
+    G1 E-{PRIME_DISTANCE} F{PRIME_SPEED}
     G4 P200
     G1 E-{LOAD_DISTANCE} F{LOAD_SPEED}
     G4 P200
     G1 E-{PRELOAD_DISTANCE * 3} F{PRELOAD_SPEED}
+    G4 P200
     M400
 
     ;signal end of unload
@@ -281,37 +282,82 @@ gcode:
 [gcode_macro LOAD_FILAMENT]
 description: Loads new filament into toolhead. EXTRUDER_TEMP defaults to 210 if hotend is cold
 gcode:
-    {% set EXTRUDER_TEMP = params.TEMP|default(210)|int %}
-    {% set MIN_TEMP = params.TEMP|default(210)|float * 0.98 %}
+    ;define temperature local names
     {% set CURRENT_TARGET = printer.extruder.target|float %}
-    {% set Z_TARGET = [[printer.toolhead.position.z|default(0)|float + 100,printer.toolhead.axis_maximum.z|float - 10]|min, printer.toolhead.position.z|default(0)|float]|max %}
-    SAVE_GCODE_STATE NAME=LOAD_FILAMENT
-    G28 O
-    G90             ; absolute positioning
-    G1 Z{Z_TARGET}  ; move nozzle upwards
-    FRONT           ; move the toolhead to the front
+    {% set MIN_TARGET = printer.extruder.min_extrude_temp|float %}
+    {% set EXPLICIT_TARGET = params.TEMP|default(0)|int %}
+    {% set DEFAULT_TARGET = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].default_temperature|float %}
 
-    {% if EXTRUDER_TEMP != 0 %}
-        LED_PENDING
-        {% if CURRENT_TARGET < EXTRUDER_TEMP %}
-            M104 S{EXTRUDER_TEMP}                               ; only heat up if the current extruder is not already hot
-        {% endif %}
-        TEMPERATURE_WAIT SENSOR="extruder" MINIMUM={MIN_TEMP}   ; wait for min extrude temp to reach
+    ;define distance local names
+    {% set PRELOAD_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].preload_distance|float %}
+    {% set LOAD_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].load_distance|float %}
+    {% set PRIME_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_distance|float %}
+
+    ;define speed local names
+    {% set PRELOAD_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].preload_speed|float %}
+    {% set LOAD_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].load_speed|float %}
+    {% set PRIME_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_speed|float %}
+
+    ;save state
+    SAVE_GCODE_STATE NAME=UNLOAD_FILAMENT
+
+    ;home if needed (per axis) and move to load position
+    LED_WORKING
+    G28 X Y Z O
+    LOAD_POSITION
+
+    ;set/wait for extruder temperature
+    LED_PENDING
+    ; heat to parameter if valid
+    {% if EXPLICIT_TARGET >= MIN_TARGET %}
+        M109 S{EXPLICIT_TARGET}
+    ; else heat to standing target if valid
+    {% elif CURRENT_TARGET > MIN_TARGET %}
+        M109 S{CURRENT_TARGET}
+    ; else heat to default target
+    {% else %}
+        M109 S{DEFAULT_TARGET}
     {% endif %}
 
+    ;deprime and unload
     LED_WORKING
-    M83                         ; set extruder to relative mode
-    M106 S255                   ; Set part cooling fan to max    
-    G1 E400 F1200               ; extrude slowly
-    G1 E20 F600
-    M107                        ; turn off part cooling fan
-    M400                        ; wait for moves to finish
-    M300 P200                   ; two short beeps to indicate load complete
-    G4 P100
-    M300 P200
-    RESTORE_GCODE_STATE NAME=LOAD_FILAMENT
-    M117 Load Complete!
+    M83
+    G1 E{PRELOAD_DISTANCE} F{PRELOAD_SPEED}
+    G4 P200
+    G1 E{LOAD_DISTANCE} F{LOAD_SPEED}
+    G4 P200
+    G1 E{PRIME_DISTANCE} F{PRIME_SPEED}
+    G4 P200
+    M400
+
+    ;prompt for extra purge
+    _PROMPT_PURGE
+
+    ;mark complete load
+    M300 P400
     LED_READY
+    M117 Unload complete
+    RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT
+
+
+[gcode_macro _PROMPT_PURGE]
+gcode:
+    RESPOND TYPE=command MSG="action:prompt_begin Load Filament"
+    RESPOND TYPE=command MSG="action:prompt_text Continue purging?"
+    RESPOND TYPE=command MSG="action:prompt_footer_button Purge|_PURGE_MORE|secondary"
+    RESPOND TYPE=command MSG="action:prompt_footer_button Continue||primary"
+    RESPOND TYPE=command MSG="action:prompt_show"
+
+
+[gcode_macro _PURGE_MORE]
+gcode:
+    {% set PRIME_DISTANCE = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_distance|float %}
+    {% set PRIME_SPEED = printer["gcode_macro _FILAMENT_CHANGE_VARIABLES"].prime_speed|float %}
+    M83
+    G1 E{PRIME_DISTANCE} F{PRIME_SPEED}
+    G4 P200
+    M400
+    _PROMPT_PURGE
 
 
 [gcode_macro M600]

--- a/positron_macros.cfg
+++ b/positron_macros.cfg
@@ -195,13 +195,14 @@ gcode:
 
 
 [gcode_macro LOAD_POSITION]
-description: Move the toolhead to the front left corner
+description: Move the toolhead to the front left corner and raise the nozzle
 gcode:
-    G28 X Y O
+    G28 X Y Z O
     {% set x_left  = printer.toolhead.axis_minimum.x|float + 10 %}
     {% set y_front = printer.toolhead.axis_maximum.y|float - 10 %}
+    {% set z_up = [[printer.toolhead.position.z|default(0)|float + 100,printer.toolhead.axis_maximum.z|float - 10]|min, printer.toolhead.position.z|default(0)|float]|max %}
     G90
-    G0 X{x_left} Y{y_front} F7800
+    G0 X{x_left} Y{y_front} Z{z_up} F7800
 
 
 #####################################################################


### PR DESCRIPTION
The New Start Update will improve upon and add advanced functionality to the parts of the configuration that have to do with starting a print, starting using the printer after setting it up, and starting using a filament (i.e. loading). It also includes the opposites of those things (print end, stowing, and unloading) but I like fun update names more than I like long descriptive update names, so behold!

- [ ] Print start and end macros will be rewritten and organized as in #3, and an option to automatically unload filament at the end of the print will be added as well.
- [ ] Filament changing macros will (hopefully) be better and easier to use with less filament grinding and incorporating user input via KlipperScreen, so no more holding the filament up to the extruder and waiting as the temperature stabilizes.
- [ ] We'll also be adapting the 'Roll Out' stowing macro by @joescalon into the base configuration as well to make folding down the Positron as easy as possible.

This is not ready yet, but you can follow along with development or submit feedback if you like, here or in the [thread on our Discord channel](https://discord.com/channels/994721150804443266/1295536201197158500). I'll see you on the other side (or maybe still this side) of The New Start!